### PR TITLE
Convert enums to integers when returned from gdscript

### DIFF
--- a/src/clojure/godotclj/api.clj
+++ b/src/clojure/godotclj/api.clj
@@ -46,7 +46,7 @@
     "PoolStringArray"  m
     "NodePath"         m
     "Array"            m
-    "enum.Error"       m
+    "enum.Error"       (:godot/object m)
     (gdscript/->instance ob-type m)))
 
 (defn ob-method**


### PR DESCRIPTION
When calling gdscript methods like "connect", which return an enum.Error (as per gdscript api.json), the result wasn't fully converted to an int before going through the gdscript.clj which type hints the result as integer, so it was failing on the conversion.

The following is an example of the error:
```
Execution error (ClassCastException) at godotclj.api.gdscript.GodotButton/connect (gdscript.clj:52698).
class godotclj.api.InstanceGc cannot be cast to class java.lang.Number 
```