### PR TITLE
Add godot_gdnative_core_1_2_api_struct to generated functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,15 @@ $(LIB)/godot-headers/api.json: godot-headers/api.json
 	mkdir -p $(shell dirname $@)
 	cp $< $@
 
-target/godotclj.jar: $(PROJECT_DIR)/deps.edn $(UBERJAR_DEPS) $(CLASSES)/godotclj/core/Bindings.class $(CLASSES)/godotclj/context.class $(GEN)/wrapper.json $(GEN)/wrapper.txt $(LIB)/natives/linux_64/libgodotclj_gdnative.so $(LIB)/natives/linux_64/libwrapper.so $(LIB)/godot-headers/api.json $(CLASSES)/godotclj/loader.class $(GEN)/godot_bindings.txt $(GEN)/godot_bindings.json
+$(CLASSES)/godotclj/api/gdscript.class: src/clojure/godotclj/api/gdscript.clj
+	mkdir -p $(CLASSES)
+	PATH=$(JAVA_PATH) \
+	$(CLJ) -J-Dtech.v3.datatype.graal-native=true \
+		-J-Dclojure.compiler.direct-linking=true \
+		-J-Dclojure.spec.skip-macros=true \
+		-M -e "(set! *warn-on-reflection* true) (with-bindings {#'*compile-path* (System/getenv \"CLASSES\")} (compile 'godotclj.jna-model) (compile 'godotclj.api))"
+
+target/godotclj.jar: $(PROJECT_DIR)/deps.edn $(UBERJAR_DEPS) $(CLASSES)/godotclj/core/Bindings.class $(CLASSES)/godotclj/context.class $(GEN)/wrapper.json $(GEN)/wrapper.txt $(LIB)/natives/linux_64/libgodotclj_gdnative.so $(LIB)/natives/linux_64/libwrapper.so $(LIB)/godot-headers/api.json $(CLASSES)/godotclj/api/gdscript.class $(CLASSES)/godotclj/loader.class $(GEN)/godot_bindings.txt $(GEN)/godot_bindings.json
 	mkdir -p $(shell dirname $@)
 	mkdir -p $(CLASSES)
 	mkdir -p $(BUILD)

--- a/Makefile
+++ b/Makefile
@@ -196,15 +196,7 @@ $(LIB)/godot-headers/api.json: godot-headers/api.json
 	mkdir -p $(shell dirname $@)
 	cp $< $@
 
-$(CLASSES)/godotclj/api/gdscript.class: src/clojure/godotclj/api/gdscript.clj
-	mkdir -p $(CLASSES)
-	PATH=$(JAVA_PATH) \
-	$(CLJ) -J-Dtech.v3.datatype.graal-native=true \
-		-J-Dclojure.compiler.direct-linking=true \
-		-J-Dclojure.spec.skip-macros=true \
-		-M -e "(set! *warn-on-reflection* true) (with-bindings {#'*compile-path* (System/getenv \"CLASSES\")} (compile 'godotclj.jna-model) (compile 'godotclj.api))"
-
-target/godotclj.jar: $(PROJECT_DIR)/deps.edn $(UBERJAR_DEPS) $(CLASSES)/godotclj/core/Bindings.class $(CLASSES)/godotclj/context.class $(GEN)/wrapper.json $(GEN)/wrapper.txt $(LIB)/natives/linux_64/libgodotclj_gdnative.so $(LIB)/natives/linux_64/libwrapper.so $(LIB)/godot-headers/api.json $(CLASSES)/godotclj/api/gdscript.class $(CLASSES)/godotclj/loader.class $(GEN)/godot_bindings.txt $(GEN)/godot_bindings.json
+target/godotclj.jar: $(PROJECT_DIR)/deps.edn $(UBERJAR_DEPS) $(CLASSES)/godotclj/core/Bindings.class $(CLASSES)/godotclj/context.class $(GEN)/wrapper.json $(GEN)/wrapper.txt $(LIB)/natives/linux_64/libgodotclj_gdnative.so $(LIB)/natives/linux_64/libwrapper.so $(LIB)/godot-headers/api.json $(CLASSES)/godotclj/loader.class $(GEN)/godot_bindings.txt $(GEN)/godot_bindings.json
 	mkdir -p $(shell dirname $@)
 	mkdir -p $(CLASSES)
 	mkdir -p $(BUILD)

--- a/src/c/gdnative.c
+++ b/src/c/gdnative.c
@@ -3,6 +3,7 @@
 #include <gdnative_api_struct.gen.h>
 
 extern const godot_gdnative_core_api_struct *api;
+extern const godot_gdnative_core_1_2_api_struct *api12;
 extern const godot_gdnative_ext_nativescript_api_struct *nativescript_api;
 
 #ifdef RUNTIME_GRAALVM
@@ -22,10 +23,27 @@ void GDN_EXPORT godot_gdnative_init(godot_gdnative_init_options *p_options) {
       break;
     }
   }
+
+  const godot_gdnative_api_struct* papi = (godot_gdnative_api_struct*)api;
+
+  while(papi->next) {
+    papi = papi->next;
+
+    if (GDNATIVE_CORE == papi->type && papi->version.major == 1 && papi->version.minor == 2) {
+      api12 = (godot_gdnative_core_1_2_api_struct*)papi;
+      break;
+    }
+  }
+
+  if (NULL == api12) {
+    fprintf(stderr, "Could not initialize api12\n");
+    exit(-1);
+  }
 }
 
 void GDN_EXPORT godot_gdnative_terminate(godot_gdnative_terminate_options *p_options) {
   api = NULL;
+  api12 = NULL;
   nativescript_api = NULL;
 }
 

--- a/src/c/godot_bindings.c
+++ b/src/c/godot_bindings.c
@@ -1,4 +1,6 @@
+#include <stdio.h>
 #include <gdnative_api_struct.gen.h>
 
 godot_gdnative_core_api_struct *api;
+godot_gdnative_core_1_2_api_struct *api12;
 godot_gdnative_ext_nativescript_api_struct *nativescript_api;

--- a/src/clojure/godotclj/defs.clj
+++ b/src/clojure/godotclj/defs.clj
@@ -15,9 +15,9 @@
    :functions (delay
                 (let [godot-bindings-json (godotclj.clang/read-records-json "godot_bindings.json")]
                   (concat (->> (godotclj.clang/gdnative-api-methods godot-bindings-json)
-                               (remove #{"godot_get_class_constructor"
-                                         "godot_get_global_constants"})
+                               (remove (comp #{"godot_get_class_constructor"} first))
                                vec)
+                          (godotclj.clang/gdnative-api-methods-1-2 godot-bindings-json)
                           (godotclj.clang/gdnative-nativescript-methods godot-bindings-json)
                           [["godot_get_class_constructor" {:return {:wrapped?   true
                                                                     :wrapper    {:name "godot_class_constructor_wrapper"}


### PR DESCRIPTION
- access to function godot_instance_from_id requires access to
  the godot_gdnative_core_1_2_api_struct struct
- godot_instance_from_id_wrapper is generated and can be tested as
follows:

  (.getInstanceId (->object "Object" (godot/godot_instance_from_id_wrapper (.getInstanceId (->object "Node")))))